### PR TITLE
fix iOS widget and watchOS complication

### DIFF
--- a/ZoeStatus Modern Watch App/SessionDelegate.swift
+++ b/ZoeStatus Modern Watch App/SessionDelegate.swift
@@ -73,6 +73,7 @@ class SessionDelegate: NSObject, WCSessionDelegate, ObservableObject {
             sharedDefaults?.set(sc.userName, forKey: "userName")
             sharedDefaults?.set(sc.password, forKey: "password")
             sharedDefaults?.set(sc.kamereon, forKey: "kamereon")
+            sharedDefaults?.set(sc.apikey, forKey: "apikey")
             sharedDefaults?.set(sc.vehicle, forKey: "vehicle")
             //sharedDefaults?.set(sc.api?.rawValue, forKey: "api")
             sharedDefaults?.set(sc.units!.rawValue, forKey: "units")

--- a/ZoeStatus Modern Watch Complications/ZoeStatus_Modern_Watch_Complications.swift
+++ b/ZoeStatus Modern Watch Complications/ZoeStatus_Modern_Watch_Complications.swift
@@ -33,6 +33,7 @@ struct Provider: TimelineProvider {
         // let api = sharedDefaults?.integer(forKey: "api")
         let units = sharedDefaults?.integer(forKey: "units")
         let kamereon = sharedDefaults?.string(forKey: "kamereon")
+        let apikey = sharedDefaults?.string(forKey: "apikey")
         let vehicle = sharedDefaults?.integer(forKey: "vehicle")
         // print("\(userName) \(password)")
 
@@ -42,6 +43,7 @@ struct Provider: TimelineProvider {
         /* Renault is no longer using a consistent version, i.e. battery state only works as v2 and cockpit as v1. */
         sc.units = ServiceConnection.Units(rawValue: units!)
         sc.kamereon = kamereon
+        sc.apikey = apikey
         sc.vehicle = vehicle
         
         if sc.userName == "simulation", sc.password == "simulation"
@@ -160,7 +162,7 @@ struct Provider: TimelineProvider {
         }
 
         
-        let sharedDefaults = UserDefaults(suiteName: "group.com.grm.ZoeStatus");
+        let sharedDefaults = UserDefaults(suiteName: "group.com.grm.ZoeStatusWatch");
         sharedDefaults?.synchronize()
         let newVehicle = sharedDefaults?.integer(forKey: "vehicle")
         if (sc.vehicle != newVehicle){

--- a/ZoeStatus Modern Widget/ZoeStatus_Modern_Widget.swift
+++ b/ZoeStatus Modern Widget/ZoeStatus_Modern_Widget.swift
@@ -33,6 +33,7 @@ struct Provider: TimelineProvider {
         // let api = sharedDefaults?.integer(forKey: "api")
         let units = sharedDefaults?.integer(forKey: "units")
         let kamereon = sharedDefaults?.string(forKey: "kamereon")
+        let apikey = sharedDefaults?.string(forKey: "apikey")
         let vehicle = sharedDefaults?.integer(forKey: "vehicle")
         // print("\(userName) \(password)")
 
@@ -42,6 +43,7 @@ struct Provider: TimelineProvider {
         /* Renault is no longer using a consistent version, i.e. battery state only works as v2 and cockpit as v1. */
         sc.units = ServiceConnection.Units(rawValue: units!)
         sc.kamereon = kamereon
+        sc.apikey = apikey
         sc.vehicle = vehicle
         
         if sc.userName == "simulation", sc.password == "simulation"


### PR DESCRIPTION
Related to #1

- `apikey` appears to be missing in the widget/complication
- fixed watch complication refresh path