### PR TITLE
Fix charging indicator when plugged in but not charging

### DIFF
--- a/ZEServices/MyR.swift
+++ b/ZEServices/MyR.swift
@@ -582,7 +582,7 @@ public class MyR {
                 // batteryState(error:charging:plugged:charge_level:remaining_range:last_update:charging_point:remaining_time:)
                 
                 return (false,
-                        result!.data.attributes.chargingStatus == 1.0 || (result!.data.attributes.chargingRemainingTime ?? 0 > 0       ) /* see https://github.com/hacf-fr/renault-api/blob/main/src/renault_api/kamereon/enums.py */,
+                        result!.data.attributes.chargingStatus == 1.0 /* CHARGE_IN_PROGRESS; see https://github.com/hacf-fr/renault-api/blob/main/src/renault_api/kamereon/enums.py */,
                         result!.data.attributes.plugStatus > 0,
                         UInt8(result!.data.attributes.batteryLevel ?? 0),
                         result!.data.attributes.batteryAutonomy ?? -1.0,


### PR DESCRIPTION
Problem

The charging indicator (⚡️ ✅) shows a charge in progress when the car is only plugged in — waiting for a planned charge, or after a session has finished.

Cause

MyR.swift derives the charging flag as:

`chargingStatus == 1.0 || (chargingRemainingTime ?? 0 > 0)`

The second clause treats any non-zero chargingRemainingTime as evidence of charging, but the API keeps returning that field with a stale or forward-looking value when no charge is running. chargingStatus alone already carries the answer: per the [renault-api enums](https://github.com/hacf-fr/renault-api/blob/main/src/renault_api/kamereon/enums.py) already linked in that comment, 1.0 is CHARGE_IN_PROGRESS, and every other value — not in charge, waiting for a planned charge, charge ended, energy flap opened, error — is not.

The sample payloads recorded in MyR.swift itself show the same thing: chargingStatus is -1.0 / -1.1 when unplugged and 1.0 when actually charging.

Observed payload (VIN redacted) with the car unplugged and idle:

```
{"data":{"id":"...","attributes":{"timestamp":"2026-08-21T09:00:44Z","batteryLevel":96,
"batteryAutonomy":345,"plugStatus":0,"chargingStatus":0.0,"chargingRemainingTime":20,
"chargingRemainingTimeLastUpdateDateTime":"2026-08-21T06:02:54Z"}}}
```

plugStatus: 0 (not plugged in) and chargingStatus: 0.0 (not charging) — yet chargingRemainingTime: 20 is still served, and the API's own chargingRemainingTimeLastUpdateDateTime shows that value was last updated at 06:02, nearly three hours earlier. The identical stale value was still being returned at 12:37.

With the current logic, chargingStatus == 1.0 || (chargingRemainingTime ?? 0 > 0) evaluates to true, so the app reports a charge in progress while the car is not even plugged in.

Fix

Drop the fallback clause. charging is now chargingStatus == 1.0.

Scope
V2 only. The V1 path (chargeStatus > 0) is untouched — I don't run V1 and haven't tested it.
chargingRemainingTime is unchanged and still returned as-is. It needs no gating: every consumer already tests charging before displaying it — remainingTimeToRemainingString/…ShortString in Utilities.swift, and the inline if charging, remaining_time != nil in ViewController, ZoeStatus_Modern_Widget, and ZoeStatus_Modern_Watch_Complications.
Because charging flows through the shared batteryState(...) signature, this corrects the iOS app, both widgets, the watch complication, and the watch extension together.
Testing

Running on my own ZOE V2 for about a year. Plugged in overnight with a scheduled charge at 02:00 — previously showed ⚡️ ✅ from the moment of plugging in; now shows ⚡️ ❌ until the charge actually starts.